### PR TITLE
check if link remote is true and dismiss modal on confirm

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -45,6 +45,10 @@
     var commit = modal.find('.commit');
     commit.text(element.data('commit') || 'Confirm');
 
+    if(element.data('remote')){
+      commit.attr('data-dismiss', 'modal');
+    }   
+
     var verify = element.data('verify');
     if (verify) {
       commit.prop('disabled', true);


### PR DESCRIPTION
If someone is calling the modal from a link using an ajax helper like

<%= link_to "Delete post", @post, remote: true, method: :delete %>

it is important to dismiss the modal even if the confirm button is pressed. This small change checks for the presence of  "remote: true" in the element and if found adds the 'data-dismiss' attribute to the confirm button of the modal.
