### PR TITLE
Get title from data-original-title for links with popover

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -34,7 +34,9 @@
         </div> \
       </div>');
 
-    modal.find('.modal-header h3').text(element.attr('title') || 'Are you ABSOLUTELY sure?');
+    var title = element.attr('title') || element.data('original-title') || 'Are you ABSOLUTELY sure?';
+
+    modal.find('.modal-header h3').text(title);
 
     var body = modal.find('.modal-body');
 
@@ -47,7 +49,7 @@
 
     if(element.data('remote')){
       commit.attr('data-dismiss', 'modal');
-    }   
+    }
 
     var verify = element.data('verify');
     if (verify) {


### PR DESCRIPTION
When using [popovers](http://getbootstrap.com/2.3.2/javascript.html#popovers) on links, Bootstrap removes the `title` attribute and re-adds it as `data-original-title`.

This PR will ensure that the title is still correctly set, when using popovers, by adding the modal title based on `data-original-title` if no `title` was found, and still defaults to "Are you ABSOLUTELY sure?"
