### PR TITLE
Support some additional settings

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -94,11 +94,24 @@
     }
 
     var verify = element.data('verify');
-    if (verify) {
+    var regexp = element.data('verify-regexp');
+
+    if (verify || regexp) {
       commit.prop('disabled', true);
 
+      var caseInsensitive = element.data('verify-regexp-caseinsensitive');
+      var re = (regexp) ? new RegExp(regexp, (caseInsensitive) ? "i" : "") : null;
+
+      var isMatch = function(input) {
+        if (re) {
+          return input.match(re);
+        }
+
+        return verify === input;
+      }
+
       var verification = $('<input/>', {type: 'text', class: settings.verifyClass}).on('keyup', function () {
-        commit.prop('disabled', $(this).val() !== verify);
+        commit.prop('disabled', !isMatch($(this).val()));
       });
 
       modal.on('shown', function () {


### PR DESCRIPTION
I had some needs for additional settings, and am contributing back in case it's helpful.
- Allow overriding the cancel button text setting via `data-cancel`
- Add a class to the input text box with the `verifyClass` setting (i.e. in a bootstrap environment, I add `form-control` to inherit typical textbox settings)
- Add optional support for regular expression matching via `data-verify-regexp` and `data-verify-regexp-caseinsensitive`. The last one is really long, but perhaps not frequently used. This allows for scenarios like github's "delete repository" where you can type, for example, "data-confirm-modal" or "ifad/data-confirm-modal" to confirm.
