### PR TITLE
Fix z-index to be always on top

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -83,6 +83,10 @@
       '</div>'
     );
 
+    // Make sure the z-index of this confim is always the top most modal
+    zindex = $('.modal.in').not('#'+id).css('z-index');
+    modal.css('z-index', parseInt(zindex) + 1);
+
     var title = element.attr('title') || element.data('original-title') || settings.title;
 
     modal.find('.modal-title').text(title);


### PR DESCRIPTION
I have instances where I manually alter the z-index of windows so I
don’t have to place them in different orders through my html. This
allows the confirm modal to always be the top z-index.
