### PR TITLE
Updated default z-index value

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -138,7 +138,7 @@
     );
 
     // Make sure it's always the top zindex
-    var highest = current = 0;
+    var highest = current = 1050;
     $('.modal.in').not('#'+id).each(function() {
       current = parseInt($(this).css('z-index'), 10);
       if(current > highest) {


### PR DESCRIPTION
Changed highest/default value for z-index. Modal by default stays on z-index:1 even though there are elements with higher z-indexes.