### PR TITLE
Defines the regexp variable

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -173,6 +173,7 @@
       var isMatch;
       if (options.verifyRegexp) {
         var caseInsensitive = options.verifyRegexpCaseInsensitive;
+        var regexp = options.verifyRegexp;
         var re = new RegExp(regexp, caseInsensitive ? 'i' : '');
 
         isMatch = function (input) { return input.match(re) };


### PR DESCRIPTION
Bug: The regexp variable is never defined, causing the modal to not be executed! That means that caseinsensitive validation and validation with regex would never work. Just tested that this works with the following: 
<a data-confirm="Type the code <b>URVRYF240115</b> to delete your post" data-method="delete" data-verify-regexp-caseinsensitive="true" data-verify-regexp="^URVRYF240115$" data-verify="URVRYF240115" href="/venda-de-filhotes/boxer-branco-raridade-grande-promocao-id-urvryf240115" rel="nofollow">
</a>