### PR TITLE
Add quotes to keys to fix IE error caused by using class keyword

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -105,7 +105,7 @@
         isMatch = function (input) { return verify == input };
       }
 
-      var verification = $('<input/>', {type: 'text', class: settings.verifyClass}).on('keyup', function () {
+      var verification = $('<input/>', {'type': 'text', 'class': settings.verifyClass}).on('keyup', function () {
         commit.prop('disabled', !isMatch($(this).val()));
       });
 


### PR DESCRIPTION
**bootstrap2** was producing an `Expected identifier, string or number` error in Internet Explorer 8.

See: http://stackoverflow.com/questions/2149762/possible-cases-for-javascript-error-expected-identifier-string-or-number

Quoting the keys here fixes the issue.  `class` is a reserved keyword in Internet Explorer.