### PR TITLE
Allow adding custom class to the main modal element

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -45,7 +45,8 @@
     verifyClass: '',
     elements: ['a[data-confirm]', 'button[data-confirm]', 'input[type=submit][data-confirm]'],
     focus: 'commit',
-    zIndex: 1050
+    zIndex: 1050,
+    customClass: false
   };
 
   var settings;
@@ -119,9 +120,10 @@
   var buildModal = function (options) {
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
     var fade = settings.fade ? 'fade' : '';
+    var customClass = settings.customClass ? customClass : '';
 
     var modal = $(
-      '<div id="'+id+'" class="modal '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
+      '<div id="'+id+'" class="modal '+fade+' '+customClass+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
         '<div class="modal-dialog">' +
           '<div class="modal-content">' +
             '<div class="modal-header">' +

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -46,7 +46,7 @@
     elements: ['a[data-confirm]', 'button[data-confirm]', 'input[type=submit][data-confirm]'],
     focus: 'commit',
     zIndex: 1050,
-    customClass: false
+    modalClass: false
   };
 
   var settings;
@@ -120,10 +120,10 @@
   var buildModal = function (options) {
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
     var fade = settings.fade ? 'fade' : '';
-    var customClass = settings.customClass ? settings.customClass : '';
+    var modalClass = settings.modalClass ? settings.modalClass : '';
 
     var modal = $(
-      '<div id="'+id+'" class="modal '+fade+' '+customClass+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
+      '<div id="'+id+'" class="modal '+fade+' '+modalClass+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
         '<div class="modal-dialog">' +
           '<div class="modal-content">' +
             '<div class="modal-header">' +

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -120,7 +120,7 @@
   var buildModal = function (options) {
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
     var fade = settings.fade ? 'fade' : '';
-    var customClass = settings.customClass ? customClass : '';
+    var customClass = settings.customClass ? settings.customClass : '';
 
     var modal = $(
       '<div id="'+id+'" class="modal '+fade+' '+customClass+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +


### PR DESCRIPTION
This feature allows users to add custom classes to the master modal element. It is useful when you have customized bootstrap theme which has specific modal behaviors (like the way they popup).