### PR TITLE
add support for creating ephemeral confirm modals using dataConfirmMo…

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -71,6 +71,8 @@
 
         modal.modal('hide');
       });
+
+      return modal;
     }
   };
 

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -51,7 +51,7 @@
 
     confirm: function (options) {
       // Build an ephemeral modal
-      var modal = buildEphimeralModal(options);
+      var modal = buildEphemeralModal(options);
 
       modal.modal('show');
       modal.on('hidden.bs.modal', function () {
@@ -77,9 +77,9 @@
   dataConfirmModal.restoreDefaults();
 
   // Just a hotfix for allowing that this lib supports
-  // the creation of an ephimeral confirmation but using
+  // the creation of an ephemeral confirmation but using
   // the current implementation (designed for bootstrap 2)
-  var buildEphimeralModal = function(object) {
+  var buildEphemeralModal = function(object) {
     var properties = [];
     for (var property in object) {
       if (typeof object[property] != 'function') {

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -47,10 +47,52 @@
 
     restoreDefaults: function () {
       settings = $.extend({}, defaults);
+    },
+
+    confirm: function (options) {
+      // Build an ephemeral modal
+      var modal = buildEphimeralModal(options);
+
+      modal.modal('show');
+      modal.on('hidden.bs.modal', function () {
+        modal.remove();
+      });
+
+      modal.find('.commit').on('click', function () {
+        if (options.onConfirm && options.onConfirm.call)
+          options.onConfirm.call();
+
+        modal.modal('hide');
+      });
+
+      modal.find('.cancel').on('click', function () {
+        if (options.onCancel && options.onCancel.call)
+          options.onCancel.call();
+
+        modal.modal('hide');
+      });
     }
   };
 
   dataConfirmModal.restoreDefaults();
+
+  // Just a hotfix for allowing that this lib supports
+  // the creation of an ephimeral confirmation but using
+  // the current implementation (designed for bootstrap 2)
+  var buildEphimeralModal = function(object) {
+    var properties = [];
+    for (var property in object) {
+      if (typeof object[property] != 'function') {
+        properties.push(property);
+      }
+    }
+    $tempElement = $('<div style="display:hidden;"></div>');
+    $.each(properties, function(index, property){
+      property != 'title' ? $tempElement.data(property, object[property]) : $tempElement.attr(property, object[property])
+    });
+    if($tempElement.data('confirm') == undefined){ $tempElement.data('confirm', '') }
+    return buildModal($tempElement);
+  }
 
   var buildModal = function (element) {
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);


### PR DESCRIPTION
I have added the "confirm" method to the dataConfirmModal object in the bootstrap2 version. The solution could be better, however I did not want to totally rewrite the buildModal method...