### PR TITLE
Clicking on the actual DOM element instead of the jQuery object

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -114,7 +114,7 @@
     modal.data('confirmed', false);
     modal.find('.commit').on('click', function () {
       modal.data('confirmed', true);
-      element.trigger('click');
+      element[0].click();
       modal.modal('hide');
     });
 


### PR DESCRIPTION
This addresses issue https://github.com/ifad/data-confirm-modal/issues/30

Executing a click event on the actual DOM element instead of the jQuery object allows the click event to fire correctly.

