### PR TITLE
Add support for specifying modalClass in data attributes

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -95,6 +95,7 @@
       text:         element.data('confirm'),
       focus:        element.data('focus'),
       method:       element.data('method'),
+      modalClass:   element.data('modal-class'),
       commit:       element.data('commit'),
       commitClass:  element.data('commit-class'),
       cancel:       element.data('cancel'),
@@ -124,7 +125,7 @@
   var buildModal = function (options) {
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
     var fade = settings.fade ? 'fade' : '';
-    var modalClass = settings.modalClass ? settings.modalClass : '';
+    var modalClass = options.modalClass ? options.modalClass : settings.modalClass;
 
     var modal = $(
       '<div id="'+id+'" class="modal '+fade+' '+modalClass+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +


### PR DESCRIPTION
We can set a default modalClass that is applied to all the generated modals, but you don't currently support a data-modal-class analogous to the data-commit-class and data-cancel-class attributes.

I have a simple 2-liner I can submit a PR for that adds this. It might be useful if, for example, I want some of my modals styled in red (for danger conditions) and others in green (for success conditions).