### PR TITLE
Use .html instead of .text

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -155,7 +155,7 @@
     });
     modal.css('z-index', parseInt(highest) + 1);
 
-    modal.find('.modal-title').text(options.title || settings.title);
+    modal.find('.modal-title').html(options.title || settings.title);
 
     var body = modal.find('.modal-body');
 
@@ -164,11 +164,11 @@
     });
 
     var commit = modal.find('.commit');
-    commit.text(options.commit || settings.commit);
+    commit.html(options.commit || settings.commit);
     commit.addClass(options.commitClass || settings.commitClass);
 
     var cancel = modal.find('.cancel');
-    cancel.text(options.cancel || settings.cancel);
+    cancel.html(options.cancel || settings.cancel);
     cancel.addClass(options.cancelClass || settings.cancelClass);
 
     if (options.remote) {


### PR DESCRIPTION
Hello,

Unless I'm mistaken, as per https://stackoverflow.com/a/18418270, it's recommended to use `.html` instead of `.text` when amending the contents of a page using jQuery (it's certainly faster to use `.html` over `.text`).

This PR changes the relevant `.text` entries in the JavaScript to use `.html` instead.