### PR TITLE
NodeJS `require` support: conditionally export as module (ref #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ certain value, for extra willingness confirmation (inspired by GitHub's
 
 ## Installation
 
+### Rails
+
 Add this line to your application's Gemfile:
 
     gem 'data-confirm-modal'
@@ -29,6 +31,21 @@ Then execute:
 And then require the Javascript from your `application.js`:
 
     //= require data-confirm-modal
+
+### Node
+
+Install the package:
+
+```bash
+npm install data-confirm-modal
+```
+
+Require and invoke the module within your code:
+
+```javascript
+var dataConfirmModal = require('data-confirm-modal')(jQuery);
+```
+
 
 ## Usage
 

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -35,269 +35,288 @@
    *
    */
 
-  var defaults = {
-    title: 'Are you sure?',
-    commit: 'Confirm',
-    commitClass: 'btn-danger',
-    cancel: 'Cancel',
-    cancelClass: 'btn-default',
-    fade: true,
-    verifyClass: 'form-control',
-    elements: ['a[data-confirm]', 'button[data-confirm]', 'input[type=submit][data-confirm]'],
-    focus: 'commit',
-    zIndex: 1050,
-    modalClass: false,
-    show: true
-  };
+  var initialize = function($) {
 
-  var settings;
-
-  window.dataConfirmModal = {
-    setDefaults: function (newSettings) {
-      settings = $.extend(settings, newSettings);
-    },
-
-    restoreDefaults: function () {
-      settings = $.extend({}, defaults);
-    },
-
-    confirm: function (options) {
-      // Build an ephemeral modal
-      //
-      var modal = buildModal(options);
-
-      modal.spawn();
-      modal.on('hidden.bs.modal', function () {
-        modal.remove();
-      });
-
-      modal.find('.commit').on('click', function () {
-        if (options.onConfirm && options.onConfirm.call)
-          options.onConfirm.call();
-
-        modal.modal('hide');
-      });
-
-      modal.find('.cancel').on('click', function () {
-        if (options.onCancel && options.onCancel.call)
-          options.onCancel.call();
-
-        modal.modal('hide');
-      });
-    }
-  };
-
-  dataConfirmModal.restoreDefaults();
-
-  var buildElementModal = function (element) {
-    var options = {
-      title:        element.data('title') || element.attr('title') || element.data('original-title'),
-      text:         element.data('confirm'),
-      focus:        element.data('focus'),
-      method:       element.data('method'),
-      modalClass:   element.data('modal-class'),
-      commit:       element.data('commit'),
-      commitClass:  element.data('commit-class'),
-      cancel:       element.data('cancel'),
-      cancelClass:  element.data('cancel-class'),
-      remote:       element.data('remote'),
-      verify:       element.data('verify'),
-      verifyRegexp: element.data('verify-regexp'),
-      verifyLabel:  element.data('verify-text'),
-      verifyRegexpCaseInsensitive: element.data('verify-regexp-caseinsensitive'),
-      backdrop:     element.data('backdrop'),
-      keyboard:     element.data('keyboard'),
-      show:         element.data('show')
+    // Default settings
+    var defaults = {
+      title: 'Are you sure?',
+      commit: 'Confirm',
+      commitClass: 'btn-danger',
+      cancel: 'Cancel',
+      cancelClass: 'btn-default',
+      fade: true,
+      verifyClass: 'form-control',
+      elements: ['a[data-confirm]', 'button[data-confirm]', 'input[type=submit][data-confirm]'],
+      focus: 'commit',
+      zIndex: 1050,
+      modalClass: false,
+      show: true
     };
 
-    var modal = buildModal(options);
+    // User settings
+    var settings;
 
-    modal.find('.commit').on('click', function () {
-      // Call the original event handler chain
-      element.get(0).click();
+    // Exported APIs
+    var dataConfirmModal = {
+      setDefaults: function (newSettings) {
+        settings = $.extend(settings, newSettings);
+      },
 
-      modal.modal('hide');
-    });
+      restoreDefaults: function () {
+        settings = $.extend({}, defaults);
+      },
 
-    return modal;
-  }
+      confirm: function (options) {
+        // Build an ephemeral modal
+        //
+        var modal = buildModal(options);
 
-  var buildModal = function (options) {
-    var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
-    var fade = settings.fade ? 'fade' : '';
-    var modalClass = options.modalClass ? options.modalClass : settings.modalClass;
-
-    var modal = $(
-      '<div id="'+id+'" class="modal '+modalClass+' '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
-        '<div class="modal-dialog" role="document">' +
-          '<div class="modal-content">' +
-            '<div class="modal-header">' +
-              '<h5 id="'+id+'Label" class="modal-title"></h5> ' +
-              '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>' +
-            '</div>' +
-            '<div class="modal-body"></div>' +
-            '<div class="modal-footer">' +
-              '<button class="btn cancel" data-dismiss="modal" aria-hidden="true"></button>' +
-              '<button class="btn commit"></button>' +
-            '</div>'+
-          '</div>'+
-        '</div>'+
-      '</div>'
-    );
-
-    // Make sure it's always the top zindex
-    var highest = current = settings.zIndex;
-    $('.modal.in').not('#'+id).each(function() {
-      current = parseInt($(this).css('z-index'), 10);
-      if(current > highest) {
-        highest = current
-      }
-    });
-    modal.css('z-index', parseInt(highest) + 1);
-
-    modal.find('.modal-title').text(options.title || settings.title);
-
-    var body = modal.find('.modal-body');
-
-    $.each((options.text||'').split(/\n{2}/), function (i, piece) {
-      body.append($('<p/>').html(piece));
-    });
-
-    var commit = modal.find('.commit');
-    commit.text(options.commit || settings.commit);
-    commit.addClass(options.commitClass || settings.commitClass);
-
-    var cancel = modal.find('.cancel');
-    cancel.text(options.cancel || settings.cancel);
-    cancel.addClass(options.cancelClass || settings.cancelClass);
-
-    if (options.remote) {
-      commit.attr('data-dismiss', 'modal');
-    }
-
-    if (options.verify || options.verifyRegexp) {
-      commit.prop('disabled', true);
-
-      var isMatch;
-      if (options.verifyRegexp) {
-        var caseInsensitive = options.verifyRegexpCaseInsensitive;
-        var regexp = options.verifyRegexp;
-        var re = new RegExp(regexp, caseInsensitive ? 'i' : '');
-
-        isMatch = function (input) { return input.match(re) };
-      } else {
-        isMatch = function (input) { return options.verify == input };
-      }
-
-      var verification = $('<input/>', {"type": 'text', "class": settings.verifyClass}).on('keyup', function () {
-        commit.prop('disabled', !isMatch($(this).val()));
-      });
-
-      modal.on('shown.bs.modal', function () {
-        verification.focus();
-      });
-
-      modal.on('hidden.bs.modal', function () {
-        verification.val('').trigger('keyup');
-      });
-
-      if (options.verifyLabel)
-        body.append($('<p>', {text: options.verifyLabel}))
-
-      body.append(verification);
-    }
-
-    var focus_element;
-    if (options.focus) {
-      focus_element = options.focus;
-    } else if (options.method == 'delete') {
-      focus_element = 'cancel'
-    } else {
-      focus_element = settings.focus;
-    }
-    focus_element = modal.find('.' + focus_element);
-
-    modal.on('shown.bs.modal', function () {
-      focus_element.focus();
-    });
-
-    $('body').append(modal);
-
-    modal.spawn = function() {
-      return modal.modal({
-        backdrop: options.backdrop,
-        keyboard: options.keyboard,
-        show:     options.show
-      });
-    };
-
-    return modal;
-  };
-
-
-  /**
-   * Returns a modal already built for the given element or builds a new one,
-   * caching it into the element's `confirm-modal` data attribute.
-   */
-  var getModal = function (element) {
-    var modal = element.data('confirm-modal');
-
-    if (!modal) {
-      modal = buildElementModal(element);
-      element.data('confirm-modal', modal);
-    }
-
-    return modal;
-  };
-
-  $.fn.confirmModal = function () {
-    var modal = getModal($(this));
-
-    modal.spawn();
-
-    return modal;
-  };
-
-  if ($.rails) {
-    /**
-     * Attaches to Rails' UJS adapter's 'confirm' event, triggered on elements
-     * having a `data-confirm` attribute set.
-     *
-     * If the modal is not visible, then it is spawned and the default Rails
-     * confirmation dialog is canceled.
-     *
-     * If the modal is visible, it means the handler is being called by the
-     * modal commit button click handler, as such the user has successfully
-     * clicked on the confirm button. In this case Rails' confirm function
-     * is briefly overriden, and afterwards reset when the modal is closed.
-     *
-     */
-    var window_confirm = window.confirm;
-
-    $(document).delegate(settings.elements.join(', '), 'confirm', function() {
-      var element = $(this), modal = getModal(element);
-
-      if (!modal.is(':visible')) {
         modal.spawn();
-
-        // Cancel Rails' confirmation
-        return false;
-
-      } else {
-        // Modal has been confirmed. Override Rails' handler
-        window.confirm = function () {
-          return true;
-        }
-
-        modal.one('hidden.bs.modal', function() {
-          // Reset it after modal is closed.
-          window.confirm = window_confirm;
+        modal.on('hidden.bs.modal', function () {
+          modal.remove();
         });
 
-        // Proceed with Rails' handlers
-        return true;
+        modal.find('.commit').on('click', function () {
+          if (options.onConfirm && options.onConfirm.call)
+            options.onConfirm.call();
+
+          modal.modal('hide');
+        });
+
+        modal.find('.cancel').on('click', function () {
+          if (options.onCancel && options.onCancel.call)
+            options.onCancel.call();
+
+          modal.modal('hide');
+        });
       }
-    });
+    };
+
+    // Set defaults
+    dataConfirmModal.restoreDefaults();
+
+    var buildElementModal = function (element) {
+      var options = {
+        title:        element.data('title') || element.attr('title') || element.data('original-title'),
+        text:         element.data('confirm'),
+        focus:        element.data('focus'),
+        method:       element.data('method'),
+        modalClass:   element.data('modal-class'),
+        commit:       element.data('commit'),
+        commitClass:  element.data('commit-class'),
+        cancel:       element.data('cancel'),
+        cancelClass:  element.data('cancel-class'),
+        remote:       element.data('remote'),
+        verify:       element.data('verify'),
+        verifyRegexp: element.data('verify-regexp'),
+        verifyLabel:  element.data('verify-text'),
+        verifyRegexpCaseInsensitive: element.data('verify-regexp-caseinsensitive'),
+        backdrop:     element.data('backdrop'),
+        keyboard:     element.data('keyboard'),
+        show:         element.data('show')
+      };
+
+      var modal = buildModal(options);
+
+      modal.find('.commit').on('click', function () {
+        // Call the original event handler chain
+        element.get(0).click();
+
+        modal.modal('hide');
+      });
+
+      return modal;
+    }
+
+    var buildModal = function (options) {
+      var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
+      var fade = settings.fade ? 'fade' : '';
+      var modalClass = options.modalClass ? options.modalClass : settings.modalClass;
+
+      var modal = $(
+        '<div id="'+id+'" class="modal '+modalClass+' '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
+          '<div class="modal-dialog" role="document">' +
+            '<div class="modal-content">' +
+              '<div class="modal-header">' +
+                '<h5 id="'+id+'Label" class="modal-title"></h5> ' +
+                '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>' +
+              '</div>' +
+              '<div class="modal-body"></div>' +
+              '<div class="modal-footer">' +
+                '<button class="btn cancel" data-dismiss="modal" aria-hidden="true"></button>' +
+                '<button class="btn commit"></button>' +
+              '</div>'+
+            '</div>'+
+          '</div>'+
+        '</div>'
+      );
+
+      // Make sure it's always the top zindex
+      var highest = current = settings.zIndex;
+      $('.modal.in').not('#'+id).each(function() {
+        current = parseInt($(this).css('z-index'), 10);
+        if(current > highest) {
+          highest = current
+        }
+      });
+      modal.css('z-index', parseInt(highest) + 1);
+
+      modal.find('.modal-title').text(options.title || settings.title);
+
+      var body = modal.find('.modal-body');
+
+      $.each((options.text||'').split(/\n{2}/), function (i, piece) {
+        body.append($('<p/>').html(piece));
+      });
+
+      var commit = modal.find('.commit');
+      commit.text(options.commit || settings.commit);
+      commit.addClass(options.commitClass || settings.commitClass);
+
+      var cancel = modal.find('.cancel');
+      cancel.text(options.cancel || settings.cancel);
+      cancel.addClass(options.cancelClass || settings.cancelClass);
+
+      if (options.remote) {
+        commit.attr('data-dismiss', 'modal');
+      }
+
+      if (options.verify || options.verifyRegexp) {
+        commit.prop('disabled', true);
+
+        var isMatch;
+        if (options.verifyRegexp) {
+          var caseInsensitive = options.verifyRegexpCaseInsensitive;
+          var regexp = options.verifyRegexp;
+          var re = new RegExp(regexp, caseInsensitive ? 'i' : '');
+
+          isMatch = function (input) { return input.match(re) };
+        } else {
+          isMatch = function (input) { return options.verify == input };
+        }
+
+        var verification = $('<input/>', {"type": 'text', "class": settings.verifyClass}).on('keyup', function () {
+          commit.prop('disabled', !isMatch($(this).val()));
+        });
+
+        modal.on('shown.bs.modal', function () {
+          verification.focus();
+        });
+
+        modal.on('hidden.bs.modal', function () {
+          verification.val('').trigger('keyup');
+        });
+
+        if (options.verifyLabel)
+          body.append($('<p>', {text: options.verifyLabel}))
+
+        body.append(verification);
+      }
+
+      var focus_element;
+      if (options.focus) {
+        focus_element = options.focus;
+      } else if (options.method == 'delete') {
+        focus_element = 'cancel'
+      } else {
+        focus_element = settings.focus;
+      }
+      focus_element = modal.find('.' + focus_element);
+
+      modal.on('shown.bs.modal', function () {
+        focus_element.focus();
+      });
+
+      $('body').append(modal);
+
+      modal.spawn = function() {
+        return modal.modal({
+          backdrop: options.backdrop,
+          keyboard: options.keyboard,
+          show:     options.show
+        });
+      };
+
+      return modal;
+    };
+
+
+    /**
+     * Returns a modal already built for the given element or builds a new one,
+     * caching it into the element's `confirm-modal` data attribute.
+     */
+    var getModal = function (element) {
+      var modal = element.data('confirm-modal');
+
+      if (!modal) {
+        modal = buildElementModal(element);
+        element.data('confirm-modal', modal);
+      }
+
+      return modal;
+    };
+
+    $.fn.confirmModal = function () {
+      var modal = getModal($(this));
+
+      modal.spawn();
+
+      return modal;
+    };
+
+    if ($.rails) {
+      /**
+       * Attaches to Rails' UJS adapter's 'confirm' event, triggered on elements
+       * having a `data-confirm` attribute set.
+       *
+       * If the modal is not visible, then it is spawned and the default Rails
+       * confirmation dialog is canceled.
+       *
+       * If the modal is visible, it means the handler is being called by the
+       * modal commit button click handler, as such the user has successfully
+       * clicked on the confirm button. In this case Rails' confirm function
+       * is briefly overriden, and afterwards reset when the modal is closed.
+       *
+       */
+      var window_confirm = window.confirm;
+
+      $(document).delegate(settings.elements.join(', '), 'confirm', function() {
+        var element = $(this), modal = getModal(element);
+
+        if (!modal.is(':visible')) {
+          modal.spawn();
+
+          // Cancel Rails' confirmation
+          return false;
+
+        } else {
+          // Modal has been confirmed. Override Rails' handler
+          window.confirm = function () {
+            return true;
+          }
+
+          modal.one('hidden.bs.modal', function() {
+            // Reset it after modal is closed.
+            window.confirm = window_confirm;
+          });
+
+          // Proceed with Rails' handlers
+          return true;
+        }
+      });
+    }
+
+    return dataConfirmModal;
+  };
+
+  if (typeof jQuery === 'undefined') {
+    throw new Error('Data-Confirm-Modal requires jQuery');
   }
 
-})(jQuery);
+  if(typeof module !== 'undefined' && module.exports) {
+    module.exports = initialize;
+  } else {
+    window.dataConfirmModal = initialize(jQuery);
+  }
+
+})();


### PR DESCRIPTION
This change adds full node support and avoids having jQuery defined at parsing time, so that initialisation and jQuery binding can be done afterwards.

Builds on work originally started in #54 - but it is yet untested. Help needed!