### PR TITLE
Run smoothly on B3 and B4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Add this line to your application's Gemfile:
 
     gem 'data-confirm-modal'
 
-if you are stuck on Bootstrap 2.3, use the `bootstrap2` branch:
+The library supports Bootstrap 3 and 4. If you are stuck on Bootstrap 2.3, you must
+use the `bootstrap2` branch:
 
     gem 'data-confirm-modal', github: 'ifad/data-confirm-modal', branch: 'bootstrap2'
 
@@ -32,7 +33,7 @@ And then require the Javascript from your `application.js`:
 
 ## Usage
 
-### With Rails ([example](http://jsfiddle.net/zpu4u6mh/))
+### With Rails: [example B3](https://jsfiddle.net/zpu4u6mh/), [example B4](https://jsfiddle.net/02t20nwx/)
 
 By default, the Gem's Javascript overrides Rails' [data-confirm behaviour][]
 for you, with no change required to your code. The modal is applicable to
@@ -68,7 +69,7 @@ To restore default settings use `dataConfirmModal.restoreDefaults()`.
 
 [data-confirm-behaviour]: http://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html
 
-### Without Rails, with data attributes ([example](http://jsfiddle.net/ze2Lz8tm/))
+### Without Rails, with data attributes: [example B3](https://jsfiddle.net/nugqscyx/), [example B4](https://jsfiddle.net/0g53ar5n/)
 
 Given an element with `data-confirm` attributes in place, such as
 
@@ -81,7 +82,7 @@ you can then invoke `.confirmModal()` on it using:
 that'll display the confirmation modal. If the user confirms, then the `#foo`
 link will receive a `click` event.
 
-### Without Rails, without data attributes ([example](https://jsfiddle.net/h370g63r/))
+### Without Rails, without data attributes: [example B3](https://jsfiddle.net/h370g63r/), [example B4](https://jsfiddle.net/veg879px/)
 
 Use `dataConfirmModal.confirm()` passing any of the supported options, and pass
 an `onConfirm` and `onCancel` callbacks that'll be invoked when the user clicks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/data-confirm-modal.svg)](https://badge.fury.io/rb/data-confirm-modal)
 
-Uses [Bootstrap's modals](http://twitter.github.io/bootstrap/javascript.html#modals)
+Uses [Bootstrap's modals](https://twitter.github.io/bootstrap/javascript.html#modals)
 in place of the browser's builtin `confirm()` API for links generated through Rails'
 helpers with the `:confirm` option.
 
@@ -99,7 +99,7 @@ the confirm or the cancel buttons.
 
 ### Modal Options
 
-The default [bootstrap modal options](http://getbootstrap.com/javascript/#modals-options)
+The default [bootstrap modal options](https://getbootstrap.com/javascript/#modals-options)
 can be passed either via JavaScript or through data attributes.
 
      $('#foo').confirmModal({backdrop: 'static', keyboard: false});
@@ -116,7 +116,7 @@ or
 
 ## Background
 
-Spinned off a corporate [IFAD](http://github.com/ifad/) application in which
+Spinned off a corporate [IFAD](https://github.com/ifad/) application in which
 an user did too much damage because the confirm wasn't *THAT* explicit ... ;-).
 
 ## Contributing

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -89,6 +89,31 @@
 
   dataConfirmModal.restoreDefaults();
 
+  // Detect bootstrap version, or bail out.
+  //
+  if ($.fn.modal == undefined) {
+    throw new Error("The bootstrap modal plugin does not appear to be loaded.");
+  }
+
+  if ($.fn.modal.Constructor == undefined) {
+    throw new Error("The bootstrap modal plugin does not have a Constructor ?!?");
+  }
+
+  if ($.fn.modal.Constructor.VERSION == undefined) {
+    throw new Error("The bootstrap modal plugin does not have its version defined ?!?");
+  }
+
+  var versionString = $.fn.modal.Constructor.VERSION;
+  var match = versionString.match(/^(\d)\./);
+  if (!match) {
+    throw new Error("Cannot identify Bootstrap version. Version string: " + versionString);
+  }
+
+  var bootstrapVersion = parseInt(match[1]);
+  if (bootstrapVersion != 3 && bootstrapVersion != 4) {
+    throw new Error("Unsupported bootstrap version: " + bootstrapVersion + ". data-confirm-modal supports version 3 and 4.");
+  }
+
   var buildElementModal = function (element) {
     var options = {
       title:        element.data('title') || element.attr('title') || element.data('original-title'),

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -152,13 +152,32 @@
     var fade = settings.fade ? 'fade' : '';
     var modalClass = options.modalClass ? options.modalClass : settings.modalClass;
 
+    var modalTitle = '<h5 id="'+id+'Label" class="modal-title"></h5> '
+    var modalClose = '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
+    var modalHeader;
+
+    // Bootstrap 3 and 4 have different DOMs and different CSS. In B4, the
+    // modalHeader is display:flex and the modalClose uses negative margins,
+    // so it can stay after the modalTitle.
+    //
+    // In B3, the close button floats to the right, so it must stay before
+    // the modalTitle.
+    //
+    switch (bootstrapVersion) {
+    case 3:
+      modalHeader = modalClose + modalTitle;
+      break;
+    case 4:
+      modalHeader = modalTitle + modalClose;
+      break;
+    }
+
     var modal = $(
       '<div id="'+id+'" class="modal '+modalClass+' '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
         '<div class="modal-dialog" role="document">' +
           '<div class="modal-content">' +
             '<div class="modal-header">' +
-              '<h5 id="'+id+'Label" class="modal-title"></h5> ' +
-              '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>' +
+              modalHeader +
             '</div>' +
             '<div class="modal-body"></div>' +
             '<div class="modal-footer">' +


### PR DESCRIPTION
This pull introduces conditional behaviour depending on the bootstrap version, to fix #59.

The bootstrap version is extracted from the `$.fn.modal.Constructor.VERSION`, as advertised on [B3 Documentation](https://getbootstrap.com/docs/3.3/javascript/#js-version-nums).

The `modal-header` element in the DOM of B4 uses `display:flex`, and the close button uses negative margins. On the other hand, in B3, the `modal-header` is a `display:block` and the close button floats to the right. Thus, in B3 the close button must be before the `modal-title`, whereas in B4 it must be after.