### PR TITLE
Fixes an uncaught ReferenceError in data-confirm-modal.js

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -194,7 +194,8 @@
     );
 
     // Make sure it's always the top zindex
-    var highest = current = settings.zIndex;
+    var highest, current;
+    highest = current = settings.zIndex;
     $('.modal.in').not('#'+id).each(function() {
       current = parseInt($(this).css('z-index'), 10);
       if(current > highest) {


### PR DESCRIPTION
The variable 'current' was not introduced its scope, which resulted in an uncaught ReferenceError if a variable with that name was unavailable globally.