### PR TITLE
Remove/Change methods which are deprecated by jQuery3

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -250,7 +250,7 @@
       });
 
       modal.on('shown.bs.modal', function () {
-        verification.focus();
+        verification.trigger('focus');
       });
 
       modal.on('hidden.bs.modal', function () {
@@ -274,7 +274,7 @@
     focus_element = modal.find('.' + focus_element);
 
     modal.on('shown.bs.modal', function () {
-      focus_element.focus();
+      focus_element.trigger('focus');
     });
 
     $('body').append(modal);
@@ -330,7 +330,7 @@
      */
     var window_confirm = window.confirm;
 
-    $(document).delegate(settings.elements.join(', '), 'confirm', function() {
+    $(document).on('confirm', settings.elements.join(', '), function() {
       var modal = $(this).getConfirmModal();
 
       if (!modal.is(':visible')) {


### PR DESCRIPTION
This pull request removes the methods [focus](https://api.jquery.com/focus/) (in [v3.3.0](https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/)) and [delegate](https://api.jquery.com/delegate/) (in [v3.0.0](https://api.jquery.com/category/deprecated/deprecated-3.0/)) got deprecated. 

In case of `focus` the underlying [trigger](https://api.jquery.com/trigger/) method is used, which is available since v1.0.0.
For the `delegate` method, [on](https://api.jquery.com/on/) is being used instead (added in v1.7.0).