### PR TITLE
Move modal class

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -181,9 +181,9 @@
       break;
     }
 
-    var modal = $(
-      '<div id="'+id+'" class="modal '+modalClass+' '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
-        '<div class="modal-dialog" role="document">' +
+      var modal = $(
+      '<div id="'+id+'" class="modal '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
+        '<div class="modal-dialog '+modalClass+'" role="document">' +
           '<div class="modal-content">' +
             '<div class="modal-header">' +
               modalHeader +

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -181,7 +181,7 @@
       break;
     }
 
-      var modal = $(
+    var modal = $(
       '<div id="'+id+'" class="modal '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
         '<div class="modal-dialog '+modalClass+'" role="document">' +
           '<div class="modal-content">' +


### PR DESCRIPTION
When using the `modalClass` property the class gets inserted at the wrong place, resulting in not resizing and not centering the modal on the page. Instead of placing the class in the modal div it must be used in the modal-dialog div.

Old behaviour
![bs4_old](https://user-images.githubusercontent.com/5381765/116534489-e2700700-a8e2-11eb-8e69-afbdc4fdf991.png)

New behaviour
![bs4_new](https://user-images.githubusercontent.com/5381765/116534487-e13eda00-a8e2-11eb-83e7-d0e3955c9ee3.png)



I tested the new version for both, Bootstrap 3 and 4 and created a [jsFiddle](https://jsfiddle.net/m123wrab/) (with BS4).