### PR TITLE
Fix `false` class added to modal

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -46,7 +46,7 @@
     elements: ['a[data-confirm]', 'button[data-confirm]', 'input[type=submit][data-confirm]'],
     focus: 'commit',
     zIndex: 1050,
-    modalClass: false,
+    modalClass: '',
     modalCloseContent: '&times;',
     show: true
   };


### PR DESCRIPTION
When modalClass is not specified, custom class should not be applied

Fix: #89