### PR TITLE
Feature/add dialog class

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -47,6 +47,7 @@
     focus: 'commit',
     zIndex: 1050,
     modalClass: '',
+    dialogClass: '',
     modalCloseContent: '&times;',
     show: true
   };
@@ -127,6 +128,7 @@
       focus:             element.data('focus'),
       method:            element.data('method'),
       modalClass:        element.data('modal-class'),
+      dialogClass:       element.data('dialog-class'),
       modalCloseContent: element.data('modal-close-content'),
       commit:            element.data('commit'),
       commitClass:       element.data('commit-class'),
@@ -158,7 +160,7 @@
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
     var fade = settings.fade ? 'fade' : '';
     var modalClass = options.modalClass ? options.modalClass : settings.modalClass;
-
+    var dialogClass = options.dialogClass ? options.dialogClass : settings.dialogClass;
     var modalCloseContent = options.modalCloseContent ? options.modalCloseContent : settings.modalCloseContent;
     var modalClose = '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">'+modalCloseContent+'</button>'
 
@@ -183,7 +185,7 @@
 
     var modal = $(
       '<div id="'+id+'" class="modal '+modalClass+' '+fade+'" tabindex="-1" role="dialog" aria-labelledby="'+id+'Label" aria-hidden="true">' +
-        '<div class="modal-dialog" role="document">' +
+        '<div class="modal-dialog '+dialogClass+'" role="document">' +
           '<div class="modal-content">' +
             '<div class="modal-header">' +
               modalHeader +


### PR DESCRIPTION
⚠️  Requires #90 to be merged to master. Then rebase this branch

Add dialogClass option

Add the ability to specify a custom class for the `modal-dialog`
element, allowing users to change the width of the modal

Ref: https://getbootstrap.com/docs/5.0/components/modal/#optional-sizes

Supersedes #75, #88