### PR TITLE
Add titleClass and titleElement options

### DIFF
--- a/lib/data-confirm-modal/engine.rb
+++ b/lib/data-confirm-modal/engine.rb
@@ -1,4 +1,4 @@
 module DataConfirmModal
-  class  Engine < ::Rails::Engine
+  class Engine < ::Rails::Engine
   end
 end

--- a/lib/data-confirm-modal/version.rb
+++ b/lib/data-confirm-modal/version.rb
@@ -1,3 +1,3 @@
 module DataConfirmModal
-  VERSION = '1.6.3'
+  VERSION = '1.6.4'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-confirm-modal",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "description": "Makes Rails' link_to confirm: 'foo' build a Bootstrap Modal instead of calling the browser's confirm() API.",
   "main": "vendor/assets/javascripts/data-confirm-modal.js",
   "repository": "https://github.com/ifad/data-confirm-modal.git",

--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -37,6 +37,8 @@
 
   var defaults = {
     title: 'Are you sure?',
+    titleClass: 'modal-title',
+    titleElement: 'h5',
     commit: 'Confirm',
     commitClass: 'btn-danger',
     cancel: 'Cancel',
@@ -124,6 +126,8 @@
   var buildElementModal = function (element) {
     var options = {
       title:             element.data('title') || element.attr('title') || element.data('original-title'),
+      titleClass:        element.data('title-class'),
+      titleElement:      element.data('title-element'),
       text:              element.data('confirm'),
       focus:             element.data('focus'),
       method:            element.data('method'),
@@ -159,12 +163,14 @@
   var buildModal = function (options) {
     var id = 'confirm-modal-' + String(Math.random()).slice(2, -1);
     var fade = settings.fade ? 'fade' : '';
+    var titleClass = options.titleClass ? options.titleClass : settings.titleClass;
+    var titleElement = options.titleElement ? options.titleElement : settings.titleElement;
     var modalClass = options.modalClass ? options.modalClass : settings.modalClass;
     var dialogClass = options.dialogClass ? options.dialogClass : settings.dialogClass;
     var modalCloseContent = options.modalCloseContent ? options.modalCloseContent : settings.modalCloseContent;
     var modalClose = '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">'+modalCloseContent+'</button>'
 
-    var modalTitle = '<h5 id="'+id+'Label" class="modal-title"></h5> '
+    var modalTitle = '<'+titleElement+' id="'+id+'Label" class="'+titleClass+'"></'+titleElement+'> '
     var modalHeader;
 
     // Bootstrap 3 and 4 have different DOMs and different CSS. In B4, the


### PR DESCRIPTION
Added support to change the element for the modal title and it's class. Kept the defaults.

The addition of these is needed for accessibility compliance. Screen readers should read the modal title as different headers and it would be useful to add more classes if needed as well.